### PR TITLE
error in msb and lsb value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ where
 
     /// Combine high and low bytes of i16 mag value
     fn raw_reading_to_i16(buf: &[u8], idx: usize) -> i16 {
-        let val: i16 = (buf[idx] as i16) | ((buf[idx + 1] as i16) << 8);
+        let val: i16 = ((buf[idx] as i16) << 8) | (buf[idx + 1] as i16);
         val
     }
 


### PR DESCRIPTION
Hi Todd.

I know it is an old repo but you might need it! 
The sensor sends first the MSB and then the LSB for the reading. 
https://github.com/arduino/HMC5983/blob/93cdb7eeac6db01e450cee764828ba2b4f90b6e2/HMC5983.cpp#L110

So I inverted it in your code and you have now normal range of values.